### PR TITLE
Update pathhomology_merge.m

### DIFF
--- a/pathhomology_merge.m
+++ b/pathhomology_merge.m
@@ -51,6 +51,7 @@ for p = 0:pmax
     end
     % Sort list and get indexed inclusion
     [y.allPaths{p+1}, indices] = sortrows(y.allPaths{p+1});
+    indices(indices) = 1:length(indices);   % bug fix 15.03.2022 from MY
     for i = 1:C
         inclAll{i,p+1} = indices(inclAll{i,p+1});
     end


### PR DESCRIPTION
Via MY:

"...the ordering of ph.hom is supposed to correspond to the ordering of ph.allPaths. This looks like a bug in pathhomology_merge.m (which probably wasn't thoroughly tested, since we were dealing mostly with well-connected graphs, and since dimension 0 is hard-coded to be correct).

 

In lines 52-56 of that script, I sort the allowed paths by lexicographic order (having aggregated them from the different components), and I update the inclusions from each component accordingly. However, looking at this code now, it seems I misunderstood the sortrows method, and the index it produces. I was using it as a permutation that produces the sorted list from the original, whereas it is the reverse. This can be fixed by adding one line between 53 and 54, to find the inverse permutation:

indices(indices) = 1:length(indices)

(a less cheesy way to do it would be to create a new vector, e.g. permutation, with the same size as indices, define it the same way as the above line, and update the variable name in line 55, which is now 56)

 

If I understand correctly, this bug should also garble the chain complex and boundary operators. If those symptoms are not present, then i'm not understanding the bug correctly. Either way, a quick fix would be to specify 'suppressRecursion' in the homology computations, especially for small / low-dimensional computations."